### PR TITLE
feat: tie bootstrap dep to a specific commit (latest as of 2017/03/06)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,13 +51,13 @@
     }
   },
   "peerDependencies": {
-    "bootstrap": "git://github.com/twbs/bootstrap.git#v4-dev"
+    "bootstrap": "git://github.com/twbs/bootstrap.git#95f37e4c402df37db16781995ffa1592032df9c8"
   },
   "dependencies": {
     "@progress/kendo-theme-default": "^2.0.0"
   },
   "devDependencies": {
-    "bootstrap": "git://github.com/twbs/bootstrap.git#v4-dev",
+    "bootstrap": "git://github.com/twbs/bootstrap.git#95f37e4c402df37db16781995ffa1592032df9c8",
     "@telerik/kendo-common-tasks": "^2.0.0",
     "cz-conventional-changelog": "^1.1.5",
     "ghooks": "^1.0.3",


### PR DESCRIPTION
Every now and then, updates in twbs/bootstrap tend to break kendo-theme-bootstrap. Basing the theme against a specific commit (albeit still in beta) should provide more stability.