### PR TITLE
fix(tooltip): use correct padding for collapsible tooltip

### DIFF
--- a/scss/tooltip/_theme.scss
+++ b/scss/tooltip/_theme.scss
@@ -6,6 +6,10 @@
         @include border-radius($border-radius);
     }
 
+    .k-tooltip-closable {
+        padding: $padding-y $padding-x;
+    }
+
 
     .k-callout-n { border-bottom-color: $tooltip-arrow-color; }
     .k-callout-e { border-left-color: $tooltip-arrow-color; }


### PR DESCRIPTION
closes https://github.com/telerik/kendo-theme-bootstrap/issues/150