### PR TITLE
Dateinput invalid styles

### DIFF
--- a/scss/datetime/_theme.scss
+++ b/scss/datetime/_theme.scss
@@ -63,7 +63,21 @@
     }
 
     // Datepicker
-    .k-datepicker {}
+    .k-datepicker {
+        .k-picker-wrap {
+
+            .k-i-warning {
+                color: $error;
+                right: $spacer * 2.5;
+            }
+            
+            &.k-state-invalid {
+                transition: none;
+                color: $error;
+                border-color: $error;
+            }
+        }
+    }
 
     // Timepicker
     .k-timepicker {}

--- a/scss/datetime/_theme.scss
+++ b/scss/datetime/_theme.scss
@@ -51,6 +51,17 @@
 
     }
 
+    .k-dateinput.k-state-invalid {
+        .k-textbox {
+            color: $error;
+            border-color: $error;
+        }
+
+        .k-i-warning {
+            color: $error;
+        }
+    }
+
     // Datepicker
     .k-datepicker {}
 

--- a/scss/input/_theme.scss
+++ b/scss/input/_theme.scss
@@ -137,15 +137,4 @@
     .k-maskedtextbox .k-state-invalid + .k-i-warning{
         color: $error;
     }
-
-    .k-dateinput.k-state-invalid {
-        .k-textbox {
-            color: $error;
-            border-color: $error;
-        }
-
-        .k-i-warning {
-            color: $error;
-        }
-    }
 }


### PR DESCRIPTION
This branch moves the DateInput invalid state styles from the Input group to the DateTime group and adds DateInput invalid state to the DatePicker widget (https://github.com/telerik/kendo/issues/6874).