### PR TITLE
chore: tooltip cannot be customized in theme builder

### DIFF
--- a/scss/tooltip/_theme.scss
+++ b/scss/tooltip/_theme.scss
@@ -1,10 +1,13 @@
-$tooltip-text: darken($widget-bg, 16);
+$is-light: lightness($bg-color) > 50;
+
+$resolved-tooltip-text: if($is-light, $tooltip-color, $tooltip-bg);
+$resolved-tooltip-bg: if($is-light, $tooltip-bg, $tooltip-color);
 
 @include exports("tooltip/theme") {
 
     .k-tooltip {
-        color: $tooltip-bg;
-        background-color: $widget-text;
+        color: $resolved-tooltip-text;
+        background-color: $resolved-tooltip-bg;
         @include border-radius($border-radius);
     }
 

--- a/scss/tooltip/_theme.scss
+++ b/scss/tooltip/_theme.scss
@@ -1,8 +1,10 @@
+$tooltip-text: darken($widget-bg, 16);
+
 @include exports("tooltip/theme") {
 
     .k-tooltip {
-        color: $tooltip-color;
-        background-color: $tooltip-bg;
+        color: $tooltip-bg;
+        background-color: $widget-text;
         @include border-radius($border-radius);
     }
 


### PR DESCRIPTION
Using tooltip variables depend on set common background

closes https://github.com/telerik/kendo/issues/6961