### PR TITLE
fix(Popup): Remove the top and bottom padding of Popup when used as a…

### DIFF
--- a/scss/popup/_theme.scss
+++ b/scss/popup/_theme.scss
@@ -11,6 +11,11 @@
             font-weight: 600;
             font-size: $font-size-sm;
         }
+
+        &.k-column-menu {
+            padding-top: 0;
+            padding-bottom: 0;
+        }
     }
     .k-popup > .k-group-header,
     .k-popup > .k-virtual-wrap > .k-group-header {


### PR DESCRIPTION
… column menu
Dealing with https://github.com/telerik/kendo-theme-bootstrap/issues/232
Also reproducible in Grid.
