### PR TITLE
fix(Grid): Add styles for verification tooltip

### DIFF
--- a/scss/grid/_theme.scss
+++ b/scss/grid/_theme.scss
@@ -26,6 +26,27 @@
             box-shadow: $list-item-focused-shadow;
         }
 
+        .k-tooltip.k-tooltip-validation {
+            color: $tooltip-color;
+            background-color: $tooltip-bg;
+
+            .k-callout-n {
+                border-bottom-color: $tooltip-bg;
+            }
+
+            .k-callout-e {
+                border-left-color: $tooltip-bg;
+            }
+
+            .k-callout-s {
+                border-top-color: $tooltip-bg;
+            }
+
+            .k-callout-w {
+                border-right-color: $tooltip-bg;
+            }
+        }
+
     }
 
 


### PR DESCRIPTION
Adding missing styles for the verification tooltip in the Grid as desribed in https://github.com/telerik/kendo-theme-bootstrap/issues/218