### PR TITLE
fix(multiselect): wrong items height

### DIFF
--- a/scss/multiselect/_theme.scss
+++ b/scss/multiselect/_theme.scss
@@ -19,5 +19,9 @@
 
     .k-multiselect-wrap {
         @include appearance( input );
+
+        .k-button {
+            padding: add-two(($button-padding-y-sm / 2), 1px) ($button-padding-x / 2);
+        }
     }
 }


### PR DESCRIPTION
By design, multiselect items should be 28px high. Fixing the height will address the following issue, too:

telerik/kendo-theme-bootstrap#260