### PR TITLE
fix(forms): align forms in dialog labels.

### DIFF
--- a/scss/edit-form/_theme.scss
+++ b/scss/edit-form/_theme.scss
@@ -1,1 +1,5 @@
-@include exports("edit-form/theme") {}
+@include exports("edit-form/theme") {
+	.k-edit-label {
+		padding: add-two($padding-y, -$input-border-width) 0;
+	}
+}

--- a/scss/editor/_theme.scss
+++ b/scss/editor/_theme.scss
@@ -60,4 +60,10 @@
         width: calc( #{$toolbar-inner-calc-size} );
         height: calc( #{$toolbar-inner-calc-size} );
     }
+
+    .k-editor-dialog {
+        .k-edit-label {
+            padding: add-two($padding-y, -$input-border-width) 0;
+        }
+    }
 }


### PR DESCRIPTION
Closes: telerik/kendo-theme-bootstrap#257