### PR TITLE
fix(grid): Add dirty cell indicator styling

### DIFF
--- a/scss/grid/_theme.scss
+++ b/scss/grid/_theme.scss
@@ -53,6 +53,10 @@
         th.k-sorted {
             background-color: $grid-sorted-bg;
         }
+
+        .k-dirty {
+            border-color: currentColor transparent transparent currentColor;
+        }
     }
 
 


### PR DESCRIPTION
Dealing with https://github.com/telerik/kendo-theme-default/issues/534