### PR TITLE
fix(treeview): reduce spacing between checkbox and item text

### DIFF
--- a/scss/treeview/_theme.scss
+++ b/scss/treeview/_theme.scss
@@ -14,6 +14,7 @@
         // Link
         .k-in {
             @include border-radius( $border-radius );
+            padding: $button-padding-y;
             transition: $transition;
         }
         .k-in.k-state-hover {


### PR DESCRIPTION
related https://github.com/telerik/kendo-theme-bootstrap/issues/212