### PR TITLE
fix(grid): Add missing locked footer border color

### DIFF
--- a/scss/grid/_theme.scss
+++ b/scss/grid/_theme.scss
@@ -108,7 +108,7 @@
         @include appearance( header );
 
         .k-grid-footer-locked {
-            border-color: $grid-border;
+            border-color: inherit;
         }
     }
 

--- a/scss/grid/_theme.scss
+++ b/scss/grid/_theme.scss
@@ -106,6 +106,10 @@
     }
     .k-grid-footer {
         @include appearance( header );
+
+        .k-grid-footer-locked {
+            border-color: $grid-border;
+        }
     }
 
 


### PR DESCRIPTION
Dealing with 11. in https://github.com/telerik/kendo-theme-bootstrap/issues/218 