### PR TITLE
chore: use theme-colors override for bootstrap

### DIFF
--- a/scss/_bootstrap-overrides.scss
+++ b/scss/_bootstrap-overrides.scss
@@ -1,0 +1,18 @@
+$enable-bootstrap-overrides: true !default;
+// $theme-colors: () !default;
+
+@if $enable-bootstrap-overrides {
+    // $theme-colors: map-merge((
+    //     secondary: #dee2e6,
+    // ), $theme-colors);
+    $theme-colors: (
+        primary: $blue,
+        secondary: $gray-300,
+        success: $green,
+        info: $cyan,
+        warning: $yellow,
+        danger: $red,
+        light: $gray-100,
+        dark: $gray-800
+    );
+}

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,6 +1,7 @@
 @import "~@progress/kendo-theme-default/scss/mixins/colors";
 @import "~bootstrap/scss/functions";
 @import "~bootstrap/scss/variables";
+@import "bootstrap-overrides";
 
 
 // Options


### PR DESCRIPTION
To avoid reworking the entire design due to secondary color being drastically different from previous version, we override it and use it in this form.

There is a 'on-by-default' that can be toggled off, should a customer want vanilla bootstrap theme influenced appearance.

Note: after the release of Beta 2, we need to: 1) reorder the import order; 2) uncomment part of the code and remove another part to avoid overriding customer set colors... That's due to `$theme-colors` map being "locked" in Beta 1.

/cc @inikolova @theOrlin @mvgmvg 