### PR TITLE
fix: correct main file name in NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "Bootstrap",
     "Theme"
   ],
-  "main": "scss/all.scss",
+  "main": "dist/all.css",
+  "sass": "scss/all.scss",
   "repository": {
     "type": "git",
     "url": "https://github.com/telerik/kendo-theme-bootstrap.git"


### PR DESCRIPTION
allows use in unpkg via https://unpkg.com/@progress/kendo-theme-default
also takes into account the [npm-sass importer](https://www.npmjs.com/package/npm-sass#imports)

analogue of https://github.com/telerik/kendo-theme-default/pull/728