### PR TITLE
Update bootstrap dependency to v4.0.0

### DIFF
--- a/.sassdocrc
+++ b/.sassdocrc
@@ -6,6 +6,8 @@
         "friendlyName": "Bootstrap",
     },
     "groups": {
+        "color-system": "Color System",
+        "fonts": "Fonts",
         "charts": "Charts",
         "undefined": "Common"
     }

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -42,104 +42,12 @@ The following table lists the available variables for customizing the Bootstrap 
 <th>Description</th>
 </tr>
 <tr>
-<td>$font-size</td>
-<td>
-    
-    $font-size-base
-</td>
-<td>Base font size across all components.
-</td>
-</tr>
-<tr>
-<td>$font-family</td>
-<td>
-    
-    $font-family-base
-</td>
-<td>Font family across all components.
-</td>
-</tr>
-<tr>
-<td>$font-family-monospace</td>
-<td>
-    
-    $font-family-monospace
-</td>
-<td>Font family for monospaced text. Used for styling the code.
-</td>
-</tr>
-<tr>
-<td>$line-height</td>
-<td>
-    
-    $line-height-base
-</td>
-<td>Line height used along with $font-size.
-</td>
-</tr>
-<tr>
 <td>$border-radius</td>
 <td>
     
     $border-radius
 </td>
 <td>Border radius for all components.
-</td>
-</tr>
-<tr>
-<td>$accent</td>
-<td>
-    
-    $primary
-</td>
-<td>The color that focuses the user attention.<br/>
-Used for primary buttons and for elements of primary importance across the theme.
-</td>
-</tr>
-<tr>
-<td>$accent-contrast</td>
-<td>
-    
-    contrast-wcag( $accent )
-</td>
-<td>The color used along with the accent color denoted by $accent.<br/>
-Used to provide contrast between the background and foreground colors.
-</td>
-</tr>
-<tr>
-<td>$success</td>
-<td>
-    
-    $success
-</td>
-<td>The color for error messages and states.
-</td>
-</tr>
-<tr>
-<td>$info</td>
-<td>
-    
-    $info
-</td>
-<td>The color for warning messages and states.
-</td>
-</tr>
-<tr>
-<td>$warning</td>
-<td>
-    
-    $warning
-</td>
-<td>The color for success messages and states.
-</td>
-</tr>
-<tr>
-<td>$error</td>
-<td>
-    
-    $danger
-</td>
-<td>The color for informational messages and states.
 </td>
 </tr>
 <tr>
@@ -469,6 +377,166 @@ Used to provide contrast between the background and foreground colors.
     rgba(0, 0, 0, .04)
 </td>
 <td>The color of the Chart grid lines (minor).
+</td>
+</tr>
+</table>
+
+
+### Color System
+
+<table class="theme-variables">
+<colgroup>
+<col style="white-space:nowrap; width: 200px" />
+<col style="width: 250px" />
+<col />
+</colgroup>
+<tr>
+<th>Name</th>
+<th>Default value</th>
+<th>Description</th>
+</tr>
+<tr>
+<td>$accent</td>
+<td>
+    
+    $primary
+</td>
+<td>The color that focuses the user attention.<br/>
+Used for primary buttons and for elements of primary importance across the theme.
+</td>
+</tr>
+<tr>
+<td>$accent-contrast</td>
+<td>
+    
+    contrast-wcag( $accent )
+</td>
+<td>The color used along with the accent color denoted by $accent.<br/>
+Used to provide contrast between the background and foreground colors.
+</td>
+</tr>
+<tr>
+<td>$success</td>
+<td>
+    
+    $success
+</td>
+<td>The color for error messages and states.
+</td>
+</tr>
+<tr>
+<td>$info</td>
+<td>
+    
+    $info
+</td>
+<td>The color for warning messages and states.
+</td>
+</tr>
+<tr>
+<td>$warning</td>
+<td>
+    
+    $warning
+</td>
+<td>The color for success messages and states.
+</td>
+</tr>
+<tr>
+<td>$error</td>
+<td>
+    
+    $danger
+</td>
+<td>The color for informational messages and states.
+</td>
+</tr>
+<tr>
+<td>$color-level-step</td>
+<td>
+    
+    $theme-color-interval
+</td>
+<td>Set a specific jump point for requesting color jumps
+</td>
+</tr>
+<tr>
+<td>$yiq-threshold</td>
+<td>
+    
+    $yiq-contrasted-threshold
+</td>
+<td>The yiq lightness value that determines when the lightness of color changes from "dark" to "light". Acceptable values are between 0 and 255.
+</td>
+</tr>
+<tr>
+<td>$yiq-dark</td>
+<td>
+    
+    $yiq-text-dark
+</td>
+<td>Dark color for use in YIQ color contrast function.
+</td>
+</tr>
+<tr>
+<td>$yiq-light</td>
+<td>
+    
+    $yiq-text-light
+</td>
+<td>Light color for use in YIQ color contrast function.
+</td>
+</tr>
+</table>
+
+
+### Fonts
+
+<table class="theme-variables">
+<colgroup>
+<col style="white-space:nowrap; width: 200px" />
+<col style="width: 250px" />
+<col />
+</colgroup>
+<tr>
+<th>Name</th>
+<th>Default value</th>
+<th>Description</th>
+</tr>
+<tr>
+<td>$font-size</td>
+<td>
+    
+    $font-size-base
+</td>
+<td>Base font size across all components.
+</td>
+</tr>
+<tr>
+<td>$font-family</td>
+<td>
+    
+    $font-family-base
+</td>
+<td>Font family across all components.
+</td>
+</tr>
+<tr>
+<td>$font-family-monospace</td>
+<td>
+    
+    $font-family-monospace
+</td>
+<td>Font family for monospaced text. Used for styling the code.
+</td>
+</tr>
+<tr>
+<td>$line-height</td>
+<td>
+    
+    $line-height-base
+</td>
+<td>Line height used along with $font-size.
 </td>
 </tr>
 </table>

--- a/package.json
+++ b/package.json
@@ -66,13 +66,13 @@
     }
   },
   "peerDependencies": {
-    "bootstrap": "4.0.0-beta.2"
+    "bootstrap": "4.0.0"
   },
   "dependencies": {
     "@progress/kendo-theme-default": "^2.0.0"
   },
   "devDependencies": {
-    "bootstrap": "4.0.0-beta.2",
+    "bootstrap": "4.0.0",
     "@telerik/kendo-common-tasks": "^3.0.0",
     "@telerik/semantic-prerelease": "^1.0.0",
     "cz-conventional-changelog": "^1.1.5",

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -62,17 +62,17 @@ $header-padding-y: $card-spacer-y !default;
 $form-line-height: $input-btn-line-height !default;
 $form-line-height-em: $form-line-height * 1em !default;
 
-$button-padding-x: $input-btn-padding-x !default;
-$button-padding-y: $input-btn-padding-y !default;
-$button-padding-x-sm: $input-btn-padding-x-sm !default;
-$button-padding-y-sm: $input-btn-padding-y-sm !default;
+$button-padding-x: $btn-padding-x !default;
+$button-padding-y: $btn-padding-y !default;
+$button-padding-x-sm: $btn-padding-x-sm !default;
+$button-padding-y-sm: $btn-padding-y-sm !default;
 $button-calc-size: #{$form-line-height-em} + #{$button-padding-y * 2} + 2px;
 $button-inner-calc-size: #{$form-line-height-em} + #{$button-padding-y * 2};
 
-$input-padding-x: $input-btn-padding-x !default;
-$input-padding-y: $input-btn-padding-y !default;
-$input-padding-x-sm: $input-btn-padding-x-sm !default;
-$input-padding-y-sm: $input-btn-padding-y-sm !default;
+$input-padding-x: $input-padding-x !default;
+$input-padding-y: $input-padding-y !default;
+$input-padding-x-sm: $input-padding-x-sm !default;
+$input-padding-y-sm: $input-padding-y-sm !default;
 $input-calc-size: #{$form-line-height-em} + #{$input-padding-y * 2} + 2px;
 $input-inner-calc-size: #{$form-line-height-em} + #{$input-padding-y * 2};
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -11,6 +11,32 @@ $enable-gradients: $enable-gradients !default;
 $enable-transitions: $enable-transitions !default;
 
 
+// Theme colors
+/// The color that focuses the user attention.
+/// Used for primary buttons and for elements of primary importance across the theme.
+$accent: $primary !default;
+
+/// The color used along with the accent color denoted by $accent.
+/// Used to provide contrast between the background and foreground colors.
+$accent-contrast: contrast-wcag( $accent ) !default;
+
+/// The color for error messages and states.
+$success: $success !default;
+
+/// The color for warning messages and states.
+$info: $info !default;
+
+/// The color for success messages and states.
+$warning: $warning !default;
+
+/// The color for informational messages and states.
+$error: $danger !default;
+
+$rgba-transparent: rgba( 0, 0, 0, 0 );
+
+$color-level-step: $theme-color-interval !default;
+
+
 // Contrast
 /// The yiq lightness value that determines when the lightness of color changes from "dark" to "light". Acceptable values are between 0 and 255.
 $yiq-threshold: $yiq-contrasted-threshold !default;
@@ -117,29 +143,6 @@ $progressbar-height: $progress-height !default;
 
 $zindex-popup: 1;
 $zindex-window: 2;
-
-$rgba-transparent: rgba( 0, 0, 0, 0 );
-
-
-// Theme colors
-/// The color that focuses the user attention.
-/// Used for primary buttons and for elements of primary importance across the theme.
-$accent: $primary !default;
-
-/// The color used along with the accent color denoted by $accent.
-/// Used to provide contrast between the background and foreground colors.
-$accent-contrast: contrast-wcag( $accent ) !default;
-
-/// The color for error messages and states.
-$success: $success !default;
-/// The color for warning messages and states.
-$info: $info !default;
-/// The color for success messages and states.
-$warning: $warning !default;
-/// The color for informational messages and states.
-$error: $danger !default;
-
-$color-level-step: $theme-color-interval !default;
 
 $text-color: $body-color !default;
 $bg-color: $body-bg !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -14,47 +14,63 @@ $enable-transitions: $enable-transitions !default;
 // Theme colors
 /// The color that focuses the user attention.
 /// Used for primary buttons and for elements of primary importance across the theme.
+/// @group color-system
 $accent: $primary !default;
 
 /// The color used along with the accent color denoted by $accent.
 /// Used to provide contrast between the background and foreground colors.
+/// @group color-system
 $accent-contrast: contrast-wcag( $accent ) !default;
 
 /// The color for error messages and states.
+/// @group color-system
 $success: $success !default;
 
 /// The color for warning messages and states.
+/// @group color-system
 $info: $info !default;
 
 /// The color for success messages and states.
+/// @group color-system
 $warning: $warning !default;
 
 /// The color for informational messages and states.
+/// @group color-system
 $error: $danger !default;
 
-$rgba-transparent: rgba( 0, 0, 0, 0 );
-
+/// Set a specific jump point for requesting color jumps
+/// @group color-system
 $color-level-step: $theme-color-interval !default;
+
+$rgba-transparent: rgba( 0, 0, 0, 0 );
 
 
 // Contrast
 /// The yiq lightness value that determines when the lightness of color changes from "dark" to "light". Acceptable values are between 0 and 255.
+/// @group color-system
 $yiq-threshold: $yiq-contrasted-threshold !default;
+
 /// Dark color for use in YIQ color contrast function.
+/// @group color-system
 $yiq-dark: $yiq-text-dark !default;
+
 /// Light color for use in YIQ color contrast function.
+/// @group color-system
 $yiq-light: $yiq-text-light !default;
 
 
 // Fonts
 
 /// Base font size across all components.
+/// @group fonts
 $font-size: $font-size-base !default;
 
 /// Font family across all components.
+/// @group fonts
 $font-family: $font-family-base !default;
 
 /// Font family for monospaced text. Used for styling the code.
+/// @group fonts
 $font-family-monospace:  $font-family-monospace !default;
 
 $font-size-xs: 0.75 * $font-size-base !default;
@@ -62,6 +78,7 @@ $font-size-sm: $font-size-sm !default;
 $font-size-lg: $font-size-lg !default;
 
 /// Line height used along with $font-size.
+/// @group fonts
 $line-height: $line-height-base !default;
 $line-height-sm: $line-height-sm !default;
 $line-height-lg: $line-height-lg !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -11,6 +11,15 @@ $enable-gradients: $enable-gradients !default;
 $enable-transitions: $enable-transitions !default;
 
 
+// Contrast
+/// The yiq lightness value that determines when the lightness of color changes from "dark" to "light". Acceptable values are between 0 and 255.
+$yiq-threshold: $yiq-contrasted-threshold !default;
+/// Dark color for use in YIQ color contrast function.
+$yiq-dark: $yiq-text-dark !default;
+/// Light color for use in YIQ color contrast function.
+$yiq-light: $yiq-text-light !default;
+
+
 // Fonts
 
 /// Base font size across all components.

--- a/scss/button/_theme.scss
+++ b/scss/button/_theme.scss
@@ -58,23 +58,25 @@
 
     // Outline default button
     .k-button.k-outline {
-        color: $button-border;
+        color: try-darken($button-bg, 20);
+        border-color: try-darken($button-bg, 20);
 
         // Hover state
         &:hover,
         &.k-state-hover {
-            @include fill( $button-bg, $button-border, $button-border, none );
+            @include fill( $button-text, $button-bg, $button-bg, none );
         }
     }
 
     // Outline primary button
     .k-button.k-outline.k-primary {
-        color: $primary-button-border;
+        color: $primary-button-bg;
+        border-color: $primary-button-bg;
 
         // Hover state
         &:hover,
         &.k-state-hover {
-            @include fill( $primary-button-text, $primary-button-border, $primary-button-bg, none );
+            @include fill( $primary-button-text, $primary-button-bg, $primary-button-bg, none );
         }
     }
 

--- a/scss/pager/_theme.scss
+++ b/scss/pager/_theme.scss
@@ -28,14 +28,11 @@
                 border-color: $pager-hover-border;
                 z-index: 2;
             }
-        }
 
-        .k-pager-nav,
-        .k-pager-numbers .k-link {
-            color: $link-text;
-
-            &:hover {
-                color: $link-hover-text;
+            &:focus {
+                box-shadow: $pagination-focus-box-shadow;
+                outline: 0;
+                z-index: 2;
             }
         }
 

--- a/scss/tooltip/_theme.scss
+++ b/scss/tooltip/_theme.scss
@@ -1,6 +1,7 @@
 @include exports("tooltip/theme") {
 
     .k-tooltip {
+        font-size: $tooltip-font-size;
         color: contrast-wcag($tooltip-bg);
         background-color: $tooltip-bg;
         @include border-radius($border-radius);

--- a/scss/tooltip/_theme.scss
+++ b/scss/tooltip/_theme.scss
@@ -1,13 +1,8 @@
-$is-light: lightness($bg-color) > 50;
-
-$resolved-tooltip-text: if($is-light, $tooltip-color, $tooltip-bg);
-$resolved-tooltip-bg: if($is-light, $tooltip-bg, $tooltip-color);
-
 @include exports("tooltip/theme") {
 
     .k-tooltip {
-        color: $resolved-tooltip-text;
-        background-color: $resolved-tooltip-bg;
+        color: contrast-wcag($tooltip-bg);
+        background-color: $tooltip-bg;
         @include border-radius($border-radius);
     }
 
@@ -16,9 +11,9 @@ $resolved-tooltip-bg: if($is-light, $tooltip-bg, $tooltip-color);
     }
 
 
-    .k-callout-n { border-bottom-color: $resolved-tooltip-bg; }
-    .k-callout-e { border-left-color: $resolved-tooltip-bg; }
-    .k-callout-s { border-top-color: $resolved-tooltip-bg; }
-    .k-callout-w { border-right-color: $resolved-tooltip-bg; }
+    .k-callout-n { border-bottom-color: $tooltip-bg; }
+    .k-callout-e { border-left-color: $tooltip-bg; }
+    .k-callout-s { border-top-color: $tooltip-bg; }
+    .k-callout-w { border-right-color: $tooltip-bg; }
 
 }


### PR DESCRIPTION
Update bootstrap dependency to v4.0.0

Alerts (KendoUI Notification)
- ~~Notifications need class for closeable to adjust padding. See bootstrap [dismissible alerts](https://github.com/twbs/bootstrap/blob/5068b437a45ffb9ab7b74620d9edec600b1a28aa/scss/_alert.scss#L25-L40).~~
    - resolution: leave as is
- ~~New variables for alert color levels~~
    - resolution: leave as is

Button
- [x] `$input-btn-` variables are renamed to `$btn-`
    - resolution: renamed
- ~~New variable for disabled button opacity~~
    - resolution: leave as is
- [x] Changes in outline button appearance
    - resolution: changes implemented

Forms (KendoUI inputs and pickers)
- [x] `$input-btn` variables are renamed to `$input-`
    - resolution: renamed

Nav (KendoUI Tabstrip)
- ~~Consolidation of border variables (could be unrelated)~~
    - resolution: leave as is; we need it the way it is because of sass themebuilder

Navbar (KendoUI Menu)
- [x] New variable for root item padding
    - resolution: handled on our end

Pagination (KendoUI Pager)
- [x] New focus outline for links
    - resolution: added

Tooltip
- [x] New variable for font-size
    - resolution: added

Function
- [x] contrast yiq function has a threshold, light and dark colors
    - resolution: added variables (albeit unused yet)

Variables
- [x] `$gray-600` is changed to `#6c757d`
    - resolution: no effect on us
- ~~Default border color is changed to `$gray-300`~~
    - resolution: leave as is (see themebuilder note)
- ~~Table border color is changed to `$gray-300`~~
    - resolution: leave as is (see themebuilder note)
- [x] `$input-btn` variables are base for `$input-` and `$btn-` respectively
    - resolution: changed
- ~~`$nav-tab-border-color` is changed to `$gray-300`~~
    - resolution: leave as is (see themebuilder note)
- ~~`$pagination-border-color` is changed to `$gray-300`~~
    - resolution: leave as is (see themebuilder note)
- ~~`$pagination-hover-border-color` is changed to `$gray-300`~~
    - resolution: leave as is (see themebuilder note)
- [x] Modal inner and content padding are changed
    - resolution: no effect on us

Note: those aren't necessarily issues. Rather, they are things that need to be checked.